### PR TITLE
Add WordPress publishing support for iA Writer

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -10,3 +10,8 @@
   from = "/xmlrpc"
   to = "/.netlify/functions/xmlrpc"
   status = 200
+
+[[redirects]]
+  from = "/xmlrpc.php"
+  to = "/.netlify/functions/xmlrpc"
+  status = 200

--- a/src/content/redirects.liquid
+++ b/src/content/redirects.liquid
@@ -2,8 +2,9 @@
 permalink: /_redirects
 eleventyExcludeFromCollections: true
 ---
-# XML-RPC (MarsEdit)
-/xmlrpc  /.netlify/functions/xmlrpc  200
+# XML-RPC (MarsEdit, iA Writer)
+/xmlrpc      /.netlify/functions/xmlrpc  200
+/xmlrpc.php  /.netlify/functions/xmlrpc  200
 
 # 404s
 /*  /404  404

--- a/src/content/rsd.liquid
+++ b/src/content/rsd.liquid
@@ -9,7 +9,9 @@ eleventyExcludeFromCollections: true
     <engineLink>https://www.11ty.dev</engineLink>
     <homePageLink>{{ site_url }}</homePageLink>
     <apis>
-      <api name="MetaWeblog" preferred="true" apiLink="{{ site_url }}/xmlrpc" blogID="1" />
+      <api name="WordPress" preferred="true" apiLink="{{ site_url }}/xmlrpc" blogID="1" />
+      <api name="MetaWeblog" preferred="false" apiLink="{{ site_url }}/xmlrpc" blogID="1" />
+      <api name="Blogger" preferred="false" apiLink="{{ site_url }}/xmlrpc" blogID="1" />
     </apis>
   </service>
 </rsd>


### PR DESCRIPTION
## Summary
Added WordPress API support to the MetaWeblog XML-RPC endpoint, enabling iA Writer's "WordPress" publishing mode to work alongside the existing MarsEdit integration. 

## Changes
- Added `wp.getUsersBlogs`, `wp.getOptions`, and `system.listMethods` handlers to the XML-RPC endpoint
- Updated RSD (Really Simple Discovery) to advertise WordPress as the preferred API
- Added `/xmlrpc.php` redirect (standard WordPress endpoint path)
- Generalized commit messages from "via MarsEdit" to "via XML-RPC"

## Testing
- Build passes (`npm run build`)
- RSD properly includes WordPress API with correct endpoint
- All four XML-RPC methods are implemented and authenticated

🤖 Generated with [Claude Code](https://claude.com/claude-code)